### PR TITLE
Fix meta tag for readability.

### DIFF
--- a/index.jinja2
+++ b/index.jinja2
@@ -20,7 +20,7 @@ div {
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
   <meta charset="utf-8">
   <title>tech company donations</title>
-  <meta name="description" content="donations by tech companies to us politicians">
+  <meta name="description" content="Donations by tech companies to U.S. politicians">
   <meta name="author" content="probably like someone famous">
 
   <!-- Mobile Specific Metas


### PR DESCRIPTION
When pasting https://donationsfrom.tech/ into an App that unfurls a vCard, like Slack, content in the `<meta description=""/>` tag is shown as a byline or chyron. In this context, the lack of capitalization makes the sentence read oddly – "us politicians" rather than "U.S.". 

Changed this to better reflect the intention of the website.